### PR TITLE
fix(workspace): execute @nxext/stencil migrations

### DIFF
--- a/migrations.json
+++ b/migrations.json
@@ -1,13 +1,6 @@
 {
   "migrations": [
     {
-      "version": "0.1.3",
-      "description": "update-0-1-3",
-      "factory": "./src/migrations/update-0-1-3/update-0-1-3",
-      "package": "@nxext/stencil",
-      "name": "update-0-1-3"
-    },
-    {
       "version": "1.0.0-beta0",
       "description": "update-1-0-0-beta0",
       "factory": "./src/migrations/update-1-0-0-beta0/update-1-0-0-beta0",

--- a/workspace.json
+++ b/workspace.json
@@ -135,10 +135,12 @@
           }
         },
         "serve": {
-          "builder": "@nxext/stencil:serve",
+          "builder": "@nxext/stencil:build",
           "options": {
             "projectType": "library",
-            "configPath": "libs/ui-components/stencil.config.ts"
+            "configPath": "libs/ui-components/stencil.config.ts",
+            "watch": true,
+            "serve": true
           }
         }
       }


### PR DESCRIPTION
The latest @nxext/stencil migrations were not run, which resulted in deprecated workspace settings.

When serving the Stencil library, the `@nxext/stencil:build` builder is now executed with `watch` and `serve` flags. This fixes the previous error `Cannot find builder "@nxext/stencil:serve"`.

Resolves #3